### PR TITLE
fix: remove fileFilters from post upgrade tasks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,11 +6,6 @@
   "postUpgradeTasks": {
     "commands": [
       "make release"
-    ],
-    "fileFilters": [
-      "Dockerfile.build",
-      "go.mod",
-      "go.sum"
     ]
   }
 }


### PR DESCRIPTION
# Summary
Update the post upgrade tasks to remove the file filters.  This should be left to its default value of `**/*` which causes any non-ignored file to be committed.