### PR TITLE
feat: allow wildcard to be greedy

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,14 @@
 {
 	"name": "Go",
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bullseye@sha256:f2d2a2bf200bb2de430a9eb4115fa87ae5d665a39539a2d5dee868227f786531",
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye@sha256:c4a714ff46f28f8502a69d18756b5d9d7e49c2cc3e5ca166b5f74ff80d1792d0",
 	"containerEnv": {
 		"SHELL": "/bin/zsh"
 	},
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/go:1": {
+			"version": "1.25.6"
+		},
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
 			"packages": "dnsutils"
 		}

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -34,7 +34,7 @@ jobs:
         uses: cds-snc/terraform-tools-setup@36df0d7572a15921998170395475093c183d720a # v1.3.0
         continue-on-error: true
         env:
-          CONFTEST_VERSION: 0.36.0
+          CONFTEST_VERSION: NONE
           TERRAFORM_VERSION: 1.14.0
           TERRAGRUNT_VERSION: NONE
           TF_SUMMARIZE_VERSION: NONE

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -8,8 +8,49 @@ permissions:
   contents: read
 
 jobs:
-  ci-dns-proxy:
+  ci-dns-proxy-amd64:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - test: default
+            allow_error: false
+          - test: safelist
+            allow_error: false
+            safelist: "*.githubapp.com,*.githubusercontent.com,*.hashicorp.com"
+            wildcardgreedy: "true"
+          - test: blocklist
+            allow_error: true
+            blocklist: "*.hashicorp.com"
+            wildcardgreedy: "true"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Test ${{ matrix.test }}
+        uses: ./
+        env:
+          DNS_PROXY_SAFELIST: ${{ matrix.safelist || '' }}
+          DNS_PROXY_BLOCKLIST: ${{ matrix.blocklist || '' }}
+          DNS_PROXY_WILDCARDGREEDY: ${{ matrix.wildcardgreedy || 'false' }}
+
+      - name: Run a composite action
+        uses: cds-snc/terraform-tools-setup@36df0d7572a15921998170395475093c183d720a # v1.3.0
+        continue-on-error: ${{ matrix.allow_error }}
+        env:
+          CONFTEST_VERSION: NONE
+          TERRAFORM_VERSION: 1.14.0
+          TERRAGRUNT_VERSION: NONE
+          TF_SUMMARIZE_VERSION: NONE
+          TRUFFLEHOG_VERSION: NONE
+
+      - name: cat DNS
+        run: cat /tmp/dns-proxy-action.out
+
+      - name: cat output file
+        run: cat /tmp/dns_query.log
+
+  ci-dns-proxy-arm64:
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -8,75 +8,30 @@ permissions:
   contents: read
 
 jobs:
-  ci-dns-proxy-amd64:
-    runs-on: ubuntu-latest
+  ci-dns-proxy:
     strategy:
       matrix:
-        include:
-          - test: default
-            allow_error: false
-          - test: safelist
-            allow_error: false
-            safelist: "*.githubapp.com,*.githubusercontent.com,*.hashicorp.com"
-            wildcardgreedy: "true"
-          - test: blocklist
-            allow_error: true
-            blocklist: "*.hashicorp.com"
-            wildcardgreedy: "true"
+        runner: 
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+        test: 
+          - default
+          - safelist
+          - blocklist
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Test ${{ matrix.test }}
         uses: ./
         env:
-          DNS_PROXY_SAFELIST: ${{ matrix.safelist || '' }}
-          DNS_PROXY_BLOCKLIST: ${{ matrix.blocklist || '' }}
-          DNS_PROXY_WILDCARDGREEDY: ${{ matrix.wildcardgreedy || 'false' }}
+          DNS_PROXY_SAFELIST: ${{ matrix.test == 'safelist' && '*.githubapp.com,*.githubusercontent.com,*.hashicorp.com' || '' }}
+          DNS_PROXY_BLOCKLIST: ${{ matrix.test == 'blocklist' && '*.hashicorp.com' || '' }}
+          DNS_PROXY_WILDCARDGREEDY: ${{ matrix.test != 'default' }}
 
       - name: Run a composite action
         uses: cds-snc/terraform-tools-setup@36df0d7572a15921998170395475093c183d720a # v1.3.0
-        continue-on-error: ${{ matrix.allow_error }}
-        env:
-          CONFTEST_VERSION: NONE
-          TERRAFORM_VERSION: 1.14.0
-          TERRAGRUNT_VERSION: NONE
-          TF_SUMMARIZE_VERSION: NONE
-          TRUFFLEHOG_VERSION: NONE
-
-      - name: cat DNS
-        run: cat /tmp/dns-proxy-action.out
-
-      - name: cat output file
-        run: cat /tmp/dns_query.log
-
-  ci-dns-proxy-arm64:
-    runs-on: ubuntu-24.04-arm
-    strategy:
-      matrix:
-        include:
-          - test: default
-            allow_error: false
-          - test: safelist
-            allow_error: false
-            safelist: "*.githubapp.com,*.githubusercontent.com,*.hashicorp.com"
-            wildcardgreedy: "true"
-          - test: blocklist
-            allow_error: true
-            blocklist: "*.hashicorp.com"
-            wildcardgreedy: "true"
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Test ${{ matrix.test }}
-        uses: ./
-        env:
-          DNS_PROXY_SAFELIST: ${{ matrix.safelist || '' }}
-          DNS_PROXY_BLOCKLIST: ${{ matrix.blocklist || '' }}
-          DNS_PROXY_WILDCARDGREEDY: ${{ matrix.wildcardgreedy || 'false' }}
-
-      - name: Run a composite action
-        uses: cds-snc/terraform-tools-setup@36df0d7572a15921998170395475093c183d720a # v1.3.0
-        continue-on-error: ${{ matrix.allow_error }}
+        continue-on-error: ${{ matrix.test == 'blocklist' }}
         env:
           CONFTEST_VERSION: NONE
           TERRAFORM_VERSION: 1.14.0

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -10,14 +10,34 @@ permissions:
 jobs:
   ci-dns-proxy:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - test: default
+          - test: safelist
+            safelist: "*.hashicorp.com"
+            wildcardgreedy: "true"
+          - test: blocklist
+            blocklist: "*.hashicorp.com"
+            wildcardgreedy: "true"  
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Run
-        uses: ./ # Uses an action in the root directory
+      - name: Test ${{ matrix.test }}
+        uses: ./
+        env:
+          DNS_PROXY_SAFELIST: ${{ matrix.safelist || '' }}
+          DNS_PROXY_BLOCKLIST: ${{ matrix.blocklist || '' }}
+          DNS_PROXY_WILDCARDGREEDY: ${{ matrix.wildcardgreedy || 'false' }}
 
       - name: Run a composite action
-        uses: cds-snc/terraform-tools-setup@5a19984bcb888600ad646e0caf5c6f4d0a54c165 # v1.2.0
+        uses: cds-snc/terraform-tools-setup@36df0d7572a15921998170395475093c183d720a # v1.3.0
+        env:
+          CONFTEST_VERSION: 0.36.0
+          TERRAFORM_VERSION: 1.14.0
+          TERRAGRUNT_VERSION: NONE
+          TF_SUMMARIZE_VERSION: NONE
+          TRUFFLEHOG_VERSION: NONE
 
       - name: Cat DNS
         run: cat /tmp/dns-proxy-action.out

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Run a composite action
         uses: cds-snc/terraform-tools-setup@36df0d7572a15921998170395475093c183d720a # v1.3.0
+        continue-on-error: true
         env:
           CONFTEST_VERSION: 0.36.0
           TERRAFORM_VERSION: 1.14.0

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ci-dns-proxy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - test: default
           - test: safelist
-            safelist: "*.hashicorp.com"
+            safelist: "*.githubapp.com,*.githubusercontent.com,*.hashicorp.com"
             wildcardgreedy: "true"
           - test: blocklist
             blocklist: "*.hashicorp.com"

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -14,12 +14,15 @@ jobs:
       matrix:
         include:
           - test: default
+            allow_error: false
           - test: safelist
+            allow_error: false
             safelist: "*.githubapp.com,*.githubusercontent.com,*.hashicorp.com"
             wildcardgreedy: "true"
           - test: blocklist
+            allow_error: true
             blocklist: "*.hashicorp.com"
-            wildcardgreedy: "true"  
+            wildcardgreedy: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -32,7 +35,7 @@ jobs:
 
       - name: Run a composite action
         uses: cds-snc/terraform-tools-setup@36df0d7572a15921998170395475093c183d720a # v1.3.0
-        continue-on-error: true
+        continue-on-error: ${{ matrix.allow_error }}
         env:
           CONFTEST_VERSION: NONE
           TERRAFORM_VERSION: 1.14.0
@@ -40,7 +43,7 @@ jobs:
           TF_SUMMARIZE_VERSION: NONE
           TRUFFLEHOG_VERSION: NONE
 
-      - name: Cat DNS
+      - name: cat DNS
         run: cat /tmp/dns-proxy-action.out
 
       - name: cat output file

--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -1,0 +1,21 @@
+name: CI Code
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ci-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run unit tests
+        run: make test
+
+

--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ci-code:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_docker_action.yml
+++ b/.github/workflows/ci_docker_action.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ci-dns-proxy-with-docker-action:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -8,10 +8,13 @@ permissions:
   contents: read
 
 jobs:
-  ci-latest-release:
+  ci-latest-release-amd64:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -20,4 +20,6 @@ jobs:
         run: make release-test
 
       - name: Diff binaries
-        run: diff -u ./release/latest/dns-proxy-action ./release/latest/dns-proxy-action-test || exit 1
+        run: |
+          diff -u ./release/latest/dns-proxy-action-amd64 ./release/latest/dns-proxy-action-amd64-test || exit 1
+          diff -u ./release/latest/dns-proxy-action-arm64 ./release/latest/dns-proxy-action-arm64-test || exit 1

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -8,25 +8,28 @@ permissions:
   contents: read
 
 jobs:
-  ci-latest-release-amd64:
-    runs-on: ubuntu-latest
+  ci-latest-release:
+    strategy:
+      matrix:
+        runner:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Build a new release based on the code
-        run: make release-test PLATFORM=amd64
-
-      - name: Diff binaries
-        run: diff -u ./release/latest/dns-proxy-action-amd64 ./release/latest/dns-proxy-action-amd64-test || exit 1
-
-  ci-latest-release-arm64:
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Determine platform
+        run: |
+          if [[ "${{ matrix.runner }}" == *"arm"* ]]; then
+            echo "PLATFORM=arm64" >> $GITHUB_ENV
+          else
+            echo "PLATFORM=amd64" >> $GITHUB_ENV
+          fi
 
       - name: Build a new release based on the code
-        run: make release-test PLATFORM=arm64
+        run: make release-test PLATFORM=${PLATFORM}
 
       - name: Diff binaries
-        run: diff -u ./release/latest/dns-proxy-action-arm64 ./release/latest/dns-proxy-action-arm64-test || exit 1
+        run: diff -u ./release/latest/dns-proxy-action-${PLATFORM} ./release/latest/dns-proxy-action-${PLATFORM}-test || exit 1
+
 

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ci-latest-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -13,16 +13,20 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
       - name: Build a new release based on the code
-        run: make release-test
+        run: make release-test PLATFORM=amd64
 
       - name: Diff binaries
-        run: |
-          diff -u ./release/latest/dns-proxy-action-amd64 ./release/latest/dns-proxy-action-amd64-test || exit 1
-          diff -u ./release/latest/dns-proxy-action-arm64 ./release/latest/dns-proxy-action-arm64-test || exit 1
+        run: diff -u ./release/latest/dns-proxy-action-amd64 ./release/latest/dns-proxy-action-amd64-test || exit 1
+
+  ci-latest-release-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build a new release based on the code
+        run: make release-test PLATFORM=arm64
+
+      - name: Diff binaries
+        run: diff -u ./release/latest/dns-proxy-action-arm64 ./release/latest/dns-proxy-action-arm64-test || exit 1
+

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,6 +4,9 @@ on:
     paths:
       - "**/*.sh"
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+release/latest/*test

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,7 @@
 FROM golang:1.25.6-alpine@sha256:98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92 AS build
 
+ARG TARGETARCH
+
 WORKDIR /app
 
 COPY go.mod ./
@@ -8,4 +10,4 @@ RUN go mod download
 
 COPY *.go ./
 
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /dns-proxy-action
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -o /dns-proxy-action

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.25.6-alpine@sha256:98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92 as build
+FROM golang:1.25.6-alpine@sha256:98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92 AS build
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-.PHONY: dev release release-test test
+.PHONY: dev release release-all release-test test
 .DEFAULT_GOAL := release
+
+PLATFORM ?= amd64
 
 dev:
 	@echo "Starting dev server..."
@@ -7,24 +9,20 @@ dev:
 
 release:
 	@mkdir -p release/latest
-	@docker build --platform linux/amd64 -t dns-proxy-action-build -f Dockerfile.build .
+	@docker build --platform linux/$(PLATFORM) -t dns-proxy-action-build -f Dockerfile.build .
 	@docker create -ti --name dns-proxy-action-build dns-proxy-action-build bash
-	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action-amd64
+	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action-$(PLATFORM)
 	@docker rm -f dns-proxy-action-build
-	@docker build --platform linux/arm64 -t dns-proxy-action-build -f Dockerfile.build .
-	@docker create -ti --name dns-proxy-action-build dns-proxy-action-build bash
-	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action-arm64
-	@docker rm -f dns-proxy-action-build
+
+release-all:
+	@$(MAKE) release PLATFORM=amd64
+	@$(MAKE) release PLATFORM=arm64
 
 release-test:
 	@mkdir -p release/latest
-	@docker build --platform linux/amd64 -t dns-proxy-action-build -f Dockerfile.build .
+	@docker build --platform linux/$(PLATFORM) -t dns-proxy-action-build -f Dockerfile.build .
 	@docker create -ti --name dns-proxy-action-build dns-proxy-action-build bash
-	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action-amd64-test
-	@docker rm -f dns-proxy-action-build
-	@docker build --platform linux/arm64 -t dns-proxy-action-build -f Dockerfile.build .
-	@docker create -ti --name dns-proxy-action-build dns-proxy-action-build bash
-	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action-arm64-test
+	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action-$(PLATFORM)-test
 	@docker rm -f dns-proxy-action-build
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,23 @@ dev:
 release:
 	@mkdir -p release/latest
 	@docker build --platform linux/amd64 -t dns-proxy-action-build -f Dockerfile.build .
-	@docker create -ti --name dns-proxy-action-build dns-proxy-action-build bash 
-	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action
+	@docker create -ti --name dns-proxy-action-build dns-proxy-action-build bash
+	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action-amd64
+	@docker rm -f dns-proxy-action-build
+	@docker build --platform linux/arm64 -t dns-proxy-action-build -f Dockerfile.build .
+	@docker create -ti --name dns-proxy-action-build dns-proxy-action-build bash
+	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action-arm64
 	@docker rm -f dns-proxy-action-build
 
 release-test:
 	@mkdir -p release/latest
 	@docker build --platform linux/amd64 -t dns-proxy-action-build -f Dockerfile.build .
-	@docker create -ti --name dns-proxy-action-build dns-proxy-action-build bash 
-	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action-test
+	@docker create -ti --name dns-proxy-action-build dns-proxy-action-build bash
+	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action-amd64-test
+	@docker rm -f dns-proxy-action-build
+	@docker build --platform linux/arm64 -t dns-proxy-action-build -f Dockerfile.build .
+	@docker create -ti --name dns-proxy-action-build dns-proxy-action-build bash
+	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action-arm64-test
 	@docker rm -f dns-proxy-action-build
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ dev:
 
 release:
 	@mkdir -p release/latest
-	@docker build -t dns-proxy-action-build -f Dockerfile.build .
+	@docker build --platform linux/amd64 -t dns-proxy-action-build -f Dockerfile.build .
 	@docker create -ti --name dns-proxy-action-build dns-proxy-action-build bash 
 	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action
 	@docker rm -f dns-proxy-action-build
 
 release-test:
 	@mkdir -p release/latest
-	@docker build -t dns-proxy-action-build -f Dockerfile.build .
+	@docker build --platform linux/amd64 -t dns-proxy-action-build -f Dockerfile.build .
 	@docker create -ti --name dns-proxy-action-build dns-proxy-action-build bash 
 	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action-test
 	@docker rm -f dns-proxy-action-build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev release release-test
+.PHONY: dev release release-test test
 .DEFAULT_GOAL := release
 
 dev:
@@ -18,3 +18,9 @@ release-test:
 	@docker create -ti --name dns-proxy-action-build dns-proxy-action-build bash 
 	@docker cp dns-proxy-action-build:/dns-proxy-action release/latest/dns-proxy-action-test
 	@docker rm -f dns-proxy-action-build
+
+test:
+	@echo "Installing dependencies..."
+	@go mod download
+	@echo "Running unit tests..."
+	@go test ./... -v -timeout 60s

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The action is configured through the following environment variables:
 | --- | --- | --- |
 | `DNS_PROXY_HOST` | The host to listen on | `172.17.0.1` |
 | `DNS_PROXY_LISTEN_PORT` | The port to listen on | `53` |
-| `DNS_PROXY_SAFE_LIST` | A comma-separated list of domains to allow | |
-| `DNS_PROXY_BLOCK_LIST` | A comma-separated list of domains to block | |
+| `DNS_PROXY_SAFELIST` | A comma-separated list of domains to allow | |
+| `DNS_PROXY_BLOCKLIST` | A comma-separated list of domains to block | |
 | `DNS_PROXY_UPSTREAM` | The upstream DNS server to forward requests to | `8.8.8.8` |
 | `DNS_PROXY_LOGLEVEL` | The log level to use | `info` |
 | `DNS_PROXY_FORWARDTOSENTINEL` | Whether to forward DNS requests to Microsoft Sentinel | `false` |
@@ -20,6 +20,7 @@ The action is configured through the following environment variables:
 | `DNS_PROXY_LOGANALYTICSTABLE` | The name of the Log Analytics table to forward DNS requests to | `GitHubMetadata_CI_DNS_Queries` |
 | `DNS_PROXY_OVERWRITECONFIG` | Whether to overwrite the DNS configuration on the host | `true` |
 | `DNS_PROXY_QUERYLOGFILEPATH` | The path to the query log file | `/tmp/dns-proxy-query.log` |
+| `DNS_PROXY_WILDCARDGREEDY` | `*` character behaviour for safe and block lists (greedy `*` matches one or more URL segments while non-greedy only matches one segement) | `false` |
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The action is configured through the following environment variables:
 | --- | --- | --- |
 | `DNS_PROXY_HOST` | The host to listen on | `172.17.0.1` |
 | `DNS_PROXY_PORT` | The port to listen on | `53` |
-| `DNS_PROXY_SAFELIST` | A comma-separated list of domains to allow | |
-| `DNS_PROXY_BLOCKLIST` | A comma-separated list of domains to block | |
+| `DNS_PROXY_SAFELIST` | A comma or newline separated list of domains to allow | |
+| `DNS_PROXY_BLOCKLIST` | A comma or newline separated list of domains to block | |
 | `DNS_PROXY_UPSTREAMSERVER` | The upstream DNS server to forward requests to | `8.8.8.8` |
 | `DNS_PROXY_LOGLEVEL` | The log level to use | `info` |
 | `DNS_PROXY_FORWARDTOSENTINEL` | Whether to forward DNS requests to Microsoft Sentinel | `false` |

--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ The action is configured through the following environment variables:
 | Variable | Description | Default value |
 | --- | --- | --- |
 | `DNS_PROXY_HOST` | The host to listen on | `172.17.0.1` |
-| `DNS_PROXY_LISTEN_PORT` | The port to listen on | `53` |
+| `DNS_PROXY_PORT` | The port to listen on | `53` |
 | `DNS_PROXY_SAFELIST` | A comma-separated list of domains to allow | |
 | `DNS_PROXY_BLOCKLIST` | A comma-separated list of domains to block | |
-| `DNS_PROXY_UPSTREAM` | The upstream DNS server to forward requests to | `8.8.8.8` |
+| `DNS_PROXY_UPSTREAMSERVER` | The upstream DNS server to forward requests to | `8.8.8.8` |
 | `DNS_PROXY_LOGLEVEL` | The log level to use | `info` |
 | `DNS_PROXY_FORWARDTOSENTINEL` | Whether to forward DNS requests to Microsoft Sentinel | `false` |
 | `DNS_PROXY_LOGANALYTICSWORKSPACEID` | The ID of the Log Analytics workspace to forward DNS requests to | |
 | `DNS_PROXY_LOGANALYTICSSHAREDKEY` | The key of the Log Analytics workspace to forward DNS requests to | |
 | `DNS_PROXY_LOGANALYTICSTABLE` | The name of the Log Analytics table to forward DNS requests to | `GitHubMetadata_CI_DNS_Queries` |
 | `DNS_PROXY_OVERWRITECONFIG` | Whether to overwrite the DNS configuration on the host | `true` |
-| `DNS_PROXY_QUERYLOGFILEPATH` | The path to the query log file | `/tmp/dns-proxy-query.log` |
-| `DNS_PROXY_WILDCARDGREEDY` | `*` character behaviour for safe and block lists (greedy `*` matches one or more URL segments while non-greedy only matches one segement) | `false` |
+| `DNS_PROXY_QUERYLOGFILEPATH` | The path to the query log file | `/tmp/dns_query.log` |
+| `DNS_PROXY_WILDCARDGREEDY` | `*` character behaviour for safe and block lists (greedy `*` matches zero or more domain labels while non-greedy only matches one label) | `false` |
 
 ## Example usage
 
@@ -31,7 +31,7 @@ Blocks all requests to download Terraform from Hashicorp:
 - name: Start DNS proxy
   uses: cds-snc/dns-proxy-action@main
   env: 
-    DNS_PROXY_BLOCK_LIST: "releases.hashicorp.com"
+    DNS_PROXY_BLOCKLIST: "releases.hashicorp.com"
 
 - name: Run a composite action
   uses: cds-snc/terraform-tools-setup@v1
@@ -44,7 +44,7 @@ You can also use safe-listing to allow only a specific set of domains:
 - name: Start DNS proxy
   uses: cds-snc/dns-proxy-action@main
   env: 
-    DNS_PROXY_SAFE_LIST: "github.com,githubusercontent.com,*.github.com,*.githubusercontent.com"
+    DNS_PROXY_SAFELIST: "github.com,githubusercontent.com,*.github.com,*.githubusercontent.com"
 ```
 
 Note that both safe-listing and block-listing can not be used at the same time, but using wildcards is allowed.

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,14 @@ description: "Starts a DNS Proxy"
 runs:
   using: "composite"
   steps:
-    - run: sudo -E $GITHUB_ACTION_PATH/release/latest/dns-proxy-action > /tmp/dns-proxy-action.out 2>&1 &
+    - run: |
+        ARCH=$(uname -m)
+        case "$ARCH" in
+          x86_64)  BINARY=dns-proxy-action-amd64 ;;
+          aarch64) BINARY=dns-proxy-action-arm64 ;;
+          *)        echo "Unsupported architecture: $ARCH"; exit 1 ;;
+        esac
+        sudo -E $GITHUB_ACTION_PATH/release/latest/$BINARY > /tmp/dns-proxy-action.out 2>&1 &
       shell: bash
     - run: sleep 3
       shell: bash

--- a/config.go
+++ b/config.go
@@ -48,8 +48,8 @@ func initConfig() *Config {
 
 	configuration.Host = viper.GetString("Host")
 	configuration.Port = viper.GetInt64("Port")
-	configuration.BlockList = viper.GetStringSlice("Blocklist")
-	configuration.SafeList = viper.GetStringSlice("Safelist")
+	configuration.BlockList = parseSlice(viper.GetString("Blocklist"))
+	configuration.SafeList = parseSlice(viper.GetString("Safelist"))
 	configuration.UpstreamServer = viper.GetString("UpstreamServer")
 	configuration.ForwardToSentinel = viper.GetBool("ForwardToSentinel")
 	configuration.LogAnalyticsWorkspaceId = viper.GetString("LogAnalyticsWorkspaceId")
@@ -88,4 +88,20 @@ func initConfig() *Config {
 
 	return &configuration
 
+}
+
+func parseSlice(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return []string{}
+	}
+	// Split on comma and newline (handle CRLF) and trim each entry. Ignore empty lines.
+	var parts []string
+	for _, p := range strings.FieldsFunc(s, func(r rune) bool { return r == ',' || r == '\n' || r == '\r' }) {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return parts
 }

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	QueryLogFilePath        string
 	SafeList                []string
 	UpstreamServer          string
+	WildcardGreedy          bool
 }
 
 func initConfig() *Config {
@@ -43,6 +44,7 @@ func initConfig() *Config {
 	viper.SetDefault("LogAnalyticsTable", "GitHubMetadata_CI_DNS_Queries")
 	viper.SetDefault("OverwriteConfig", true)
 	viper.SetDefault("QueryLogFilePath", "/tmp/dns_query.log")
+	viper.SetDefault("WildcardGreedy", false)
 
 	configuration.Host = viper.GetString("Host")
 	configuration.Port = viper.GetInt64("Port")
@@ -55,6 +57,7 @@ func initConfig() *Config {
 	configuration.LogAnalyticsTable = viper.GetString("LogAnalyticsTable")
 	configuration.OverwriteConfig = viper.GetBool("OverwriteConfig")
 	configuration.QueryLogFilePath = viper.GetString("QueryLogFilePath")
+	configuration.WildcardGreedy = viper.GetBool("WildcardGreedy")
 
 	// Log Level switch
 	switch strings.ToLower(viper.GetString("LogLevel")) {

--- a/config_test.go
+++ b/config_test.go
@@ -50,6 +50,9 @@ func TestInitConfig_Defaults(t *testing.T) {
 	if len(config.SafeList) != 0 {
 		t.Errorf("SafeList: expected empty slice, got %v", config.SafeList)
 	}
+	if config.WildcardGreedy {
+		t.Error("WildcardGreedy: expected false by default")
+	}
 }
 
 func TestInitConfig_HostOverride(t *testing.T) {
@@ -158,6 +161,17 @@ func TestInitConfig_LogLevels(t *testing.T) {
 				t.Errorf("LogLevel for %q: expected %v, got %v", tt.envVal, tt.expected, config.LogLevel)
 			}
 		})
+	}
+}
+
+func TestInitConfig_WildcardGreedyOverride(t *testing.T) {
+	resetViper(t)
+	t.Setenv("DNS_PROXY_WILDCARDGREEDY", "true")
+
+	config := initConfig()
+
+	if !config.WildcardGreedy {
+		t.Error("WildcardGreedy: expected true")
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -172,6 +173,56 @@ func TestInitConfig_WildcardGreedyOverride(t *testing.T) {
 
 	if !config.WildcardGreedy {
 		t.Error("WildcardGreedy: expected true")
+	}
+}
+
+func TestInitConfig_SafelistOverride(t *testing.T) {
+	resetViper(t)
+	t.Setenv("DNS_PROXY_SAFELIST", "*.githubapp.com,*.githubusercontent.com,*.hashicorp.com")
+
+	config := initConfig()
+
+	if len(config.SafeList) != 3 {
+		t.Errorf("SafeList: expected 3 entries, got %d", len(config.SafeList))
+	}
+}
+
+func TestInitConfig_BlocklistOverride(t *testing.T) {
+	resetViper(t)
+	t.Setenv("DNS_PROXY_BLOCKLIST", "*.githubapp.com,*.githubusercontent.com")
+
+	config := initConfig()
+
+	if len(config.BlockList) != 2 {
+		t.Errorf("BlockList: expected 2 entries, got %d", len(config.BlockList))
+	}
+}
+
+func TestParseSlice(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"comma", "a,b,c", []string{"a", "b", "c"}},
+		{"comma_spaces", " a, b ,c ", []string{"a", "b", "c"}},
+		{"newline_lf", "a\nb\nc", []string{"a", "b", "c"}},
+		{"newline_crlf", "a\r\nb\r\nc", []string{"a", "b", "c"}},
+		{"mixed_comma_newline", "a,b\nc", []string{"a", "b", "c"}},
+		{"single", "single", []string{"single"}},
+		{"empty", "", []string{}},
+		{"spaces_only", "   ", []string{}},
+		{"leading_trailing_commas", ",a,b,", []string{"a", "b"}},
+		{"empty_lines", "\n\na\n\n", []string{"a"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSlice(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseSlice(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/spf13/viper"
+)
+
+// resetViper clears all viper state before each config test.
+func resetViper(t *testing.T) {
+	t.Helper()
+	viper.Reset()
+}
+
+func TestInitConfig_Defaults(t *testing.T) {
+	resetViper(t)
+
+	config := initConfig()
+
+	if config.Host != "172.17.0.1" {
+		t.Errorf("Host: expected 172.17.0.1, got %q", config.Host)
+	}
+	if config.Port != 53 {
+		t.Errorf("Port: expected 53, got %d", config.Port)
+	}
+	if config.UpstreamServer != "8.8.8.8" {
+		t.Errorf("UpstreamServer: expected 8.8.8.8, got %q", config.UpstreamServer)
+	}
+	if config.ForwardToSentinel {
+		t.Error("ForwardToSentinel: expected false by default")
+	}
+	if !config.OverwriteConfig {
+		t.Error("OverwriteConfig: expected true by default")
+	}
+	if config.QueryLogFilePath != "/tmp/dns_query.log" {
+		t.Errorf("QueryLogFilePath: expected /tmp/dns_query.log, got %q", config.QueryLogFilePath)
+	}
+	if config.LogAnalyticsTable != "GitHubMetadata_CI_DNS_Queries" {
+		t.Errorf("LogAnalyticsTable: expected GitHubMetadata_CI_DNS_Queries, got %q", config.LogAnalyticsTable)
+	}
+	if config.LogLevel != zerolog.InfoLevel {
+		t.Errorf("LogLevel: expected InfoLevel, got %v", config.LogLevel)
+	}
+	if len(config.BlockList) != 0 {
+		t.Errorf("BlockList: expected empty slice, got %v", config.BlockList)
+	}
+	if len(config.SafeList) != 0 {
+		t.Errorf("SafeList: expected empty slice, got %v", config.SafeList)
+	}
+}
+
+func TestInitConfig_HostOverride(t *testing.T) {
+	resetViper(t)
+	t.Setenv("DNS_PROXY_HOST", "10.0.0.1")
+
+	config := initConfig()
+
+	if config.Host != "10.0.0.1" {
+		t.Errorf("Host: expected 10.0.0.1, got %q", config.Host)
+	}
+}
+
+func TestInitConfig_PortOverride(t *testing.T) {
+	resetViper(t)
+	t.Setenv("DNS_PROXY_PORT", "5353")
+
+	config := initConfig()
+
+	if config.Port != 5353 {
+		t.Errorf("Port: expected 5353, got %d", config.Port)
+	}
+}
+
+func TestInitConfig_UpstreamServerOverride(t *testing.T) {
+	resetViper(t)
+	t.Setenv("DNS_PROXY_UPSTREAMSERVER", "1.1.1.1")
+
+	config := initConfig()
+
+	if config.UpstreamServer != "1.1.1.1" {
+		t.Errorf("UpstreamServer: expected 1.1.1.1, got %q", config.UpstreamServer)
+	}
+}
+
+func TestInitConfig_ForwardToSentinelOverride(t *testing.T) {
+	resetViper(t)
+	t.Setenv("DNS_PROXY_FORWARDTOSENTINEL", "true")
+	t.Setenv("DNS_PROXY_LOGANALYTICSWORKSPACEID", "ws-id")
+	t.Setenv("DNS_PROXY_LOGANALYTICSSHAREDKEY", "c2VjcmV0")
+	t.Setenv("DNS_PROXY_LOGANALYTICSTABLE", "MyTable")
+
+	config := initConfig()
+
+	if !config.ForwardToSentinel {
+		t.Error("ForwardToSentinel: expected true")
+	}
+	if config.LogAnalyticsWorkspaceId != "ws-id" {
+		t.Errorf("LogAnalyticsWorkspaceId: expected ws-id, got %q", config.LogAnalyticsWorkspaceId)
+	}
+	if config.LogAnalyticsSharedKey != "c2VjcmV0" {
+		t.Errorf("LogAnalyticsSharedKey: expected c2VjcmV0, got %q", config.LogAnalyticsSharedKey)
+	}
+	if config.LogAnalyticsTable != "MyTable" {
+		t.Errorf("LogAnalyticsTable: expected MyTable, got %q", config.LogAnalyticsTable)
+	}
+}
+
+func TestInitConfig_OverwriteConfigFalse(t *testing.T) {
+	resetViper(t)
+	t.Setenv("DNS_PROXY_OVERWRITECONFIG", "false")
+
+	config := initConfig()
+
+	if config.OverwriteConfig {
+		t.Error("OverwriteConfig: expected false")
+	}
+}
+
+func TestInitConfig_QueryLogFilePathOverride(t *testing.T) {
+	resetViper(t)
+	t.Setenv("DNS_PROXY_QUERYLOGFILEPATH", "/tmp/custom_dns.log")
+
+	config := initConfig()
+
+	if config.QueryLogFilePath != "/tmp/custom_dns.log" {
+		t.Errorf("QueryLogFilePath: expected /tmp/custom_dns.log, got %q", config.QueryLogFilePath)
+	}
+}
+
+func TestInitConfig_LogLevels(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVal   string
+		expected zerolog.Level
+	}{
+		{"debug", "debug", zerolog.DebugLevel},
+		{"info", "info", zerolog.InfoLevel},
+		{"warn", "warn", zerolog.WarnLevel},
+		{"error", "error", zerolog.ErrorLevel},
+		{"fatal", "fatal", zerolog.FatalLevel},
+		{"panic", "panic", zerolog.PanicLevel},
+		{"unknown_defaults_to_info", "unknown", zerolog.InfoLevel},
+		{"uppercase_debug", "DEBUG", zerolog.DebugLevel},
+		{"mixed_case_warn", "Warn", zerolog.WarnLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetViper(t)
+			t.Setenv("DNS_PROXY_LOGLEVEL", tt.envVal)
+
+			config := initConfig()
+
+			if config.LogLevel != tt.expected {
+				t.Errorf("LogLevel for %q: expected %v, got %v", tt.envVal, tt.expected, config.LogLevel)
+			}
+		})
+	}
+}
+
+func TestInitConfig_LoggerIsConfigured(t *testing.T) {
+	resetViper(t)
+	tmp := t.TempDir()
+	t.Setenv("DNS_PROXY_QUERYLOGFILEPATH", tmp+"/q.log")
+
+	config := initConfig()
+
+	// Logger should be non-zero and usable without panic
+	var buf strings.Builder
+	log := config.Logger.With().Logger().Output(&buf)
+	log.Info().Msg("test")
+	// zerolog writes JSON; we just verify no panic occurred and something was written
+	_ = os.Remove(tmp + "/q.log") // cleanup if written
+}

--- a/dns_proxy.go
+++ b/dns_proxy.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
 	"time"
 
@@ -10,21 +11,28 @@ import (
 	layers "github.com/google/gopacket/layers"
 )
 
-func checkWildcard(wildcard string, domain string) bool {
-	wildcardParts := strings.Split(wildcard, ".")
-	domainParts := strings.Split(domain, ".")
-
-	if len(wildcardParts) != len(domainParts) {
-		return false
-	}
-
-	for i, part := range wildcardParts {
-		if part != "*" && part != domainParts[i] {
+func checkWildcard(wildcard string, domain string, greedy bool) bool {
+	// Non-greedy matching: * matches one domain segment only, and the
+	// number of segments must match
+	if !greedy {
+		wildcardParts := strings.Split(wildcard, ".")
+		domainParts := strings.Split(domain, ".")
+		if len(wildcardParts) != len(domainParts) {
 			return false
 		}
+		for i, part := range wildcardParts {
+			if part != "*" && part != domainParts[i] {
+				return false
+			}
+		}
+		return true
 	}
 
-	return true
+	// Greedy matching: * can match zero or more domain segments
+	escaped := regexp.QuoteMeta(wildcard)
+	regexStr := strings.ReplaceAll(escaped, `\*\.`, `([^.]+\.)*`)
+	regexStr = strings.ReplaceAll(regexStr, `\*`, `.*`)
+	return regexp.MustCompile("^" + regexStr + "$").MatchString(domain)
 }
 
 func dnsProxyServer(config *Config) {
@@ -84,7 +92,7 @@ func filterDns(request *layers.DNS, config *Config) bool {
 	// Check if we are using a safelist or a blocklist
 	if len(config.SafeList) > 0 {
 		for _, safeDomain := range config.SafeList {
-			if checkWildcard(safeDomain, domain) {
+			if checkWildcard(safeDomain, domain, config.WildcardGreedy) {
 				config.Logger.Info().
 					Str("domain", domain).
 					Str("action", "passed").
@@ -99,7 +107,7 @@ func filterDns(request *layers.DNS, config *Config) bool {
 		return true
 	} else {
 		for _, blockedDomain := range config.BlockList {
-			if checkWildcard(blockedDomain, domain) {
+			if checkWildcard(blockedDomain, domain, config.WildcardGreedy) {
 				config.Logger.Info().
 					Str("domain", domain).
 					Str("action", "blocked").

--- a/dns_proxy_test.go
+++ b/dns_proxy_test.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	layers "github.com/google/gopacket/layers"
+	"github.com/rs/zerolog"
+)
+
+// newDiscardLogger returns a Config with a zerolog logger that discards all output.
+func newDiscardLogger() *Config {
+	return &Config{
+		Logger: zerolog.New(io.Discard),
+	}
+}
+
+// newDNSQuery builds a minimal DNS query packet for the given domain and type.
+func newDNSQuery(domain string, qtype layers.DNSType) *layers.DNS {
+	return &layers.DNS{
+		QR: false,
+		Questions: []layers.DNSQuestion{
+			{Name: []byte(domain), Type: qtype},
+		},
+	}
+}
+
+// ─── checkWildcard ───────────────────────────────────────────────────────────
+
+func TestCheckWildcard_ExactMatch(t *testing.T) {
+	if !checkWildcard("example.com", "example.com") {
+		t.Error("expected exact match to return true")
+	}
+}
+
+func TestCheckWildcard_WildcardSingleLabel(t *testing.T) {
+	if !checkWildcard("*.example.com", "foo.example.com") {
+		t.Error("expected wildcard match to return true")
+	}
+}
+
+func TestCheckWildcard_WildcardDoesNotMatchSubdomain(t *testing.T) {
+	// *.example.com should NOT match foo.bar.example.com (different number of parts)
+	if checkWildcard("*.example.com", "foo.bar.example.com") {
+		t.Error("expected length mismatch to return false")
+	}
+}
+
+func TestCheckWildcard_WildcardWrongLabel(t *testing.T) {
+	// Wildcard matches any single label, but second part must match
+	if checkWildcard("*.example.com", "foo.other.com") {
+		t.Error("expected non-matching label to return false")
+	}
+}
+
+func TestCheckWildcard_LengthMismatch_Shorter(t *testing.T) {
+	if checkWildcard("*.example.com", "example.com") {
+		t.Error("expected shorter domain to return false")
+	}
+}
+
+func TestCheckWildcard_LengthMismatch_Longer(t *testing.T) {
+	if checkWildcard("example.com", "sub.example.com") {
+		t.Error("expected longer domain to return false")
+	}
+}
+
+func TestCheckWildcard_MultipleWildcards(t *testing.T) {
+	if !checkWildcard("*.*", "foo.bar") {
+		t.Error("expected double wildcard to match foo.bar")
+	}
+}
+
+func TestCheckWildcard_NoMatch(t *testing.T) {
+	if checkWildcard("example.com", "other.com") {
+		t.Error("expected non-matching domain to return false")
+	}
+}
+
+// ─── filterDns ───────────────────────────────────────────────────────────────
+
+func TestFilterDns_Response_NotFiltered(t *testing.T) {
+	cfg := newDiscardLogger()
+	req := &layers.DNS{QR: true, Questions: []layers.DNSQuestion{
+		{Name: []byte("example.com"), Type: layers.DNSTypeA},
+	}}
+	if filterDns(req, cfg) {
+		t.Error("DNS response (QR=true) should not be filtered")
+	}
+}
+
+func TestFilterDns_MultipleQuestions_NotFiltered(t *testing.T) {
+	cfg := newDiscardLogger()
+	req := &layers.DNS{
+		QR: false,
+		Questions: []layers.DNSQuestion{
+			{Name: []byte("a.com"), Type: layers.DNSTypeA},
+			{Name: []byte("b.com"), Type: layers.DNSTypeA},
+		},
+	}
+	if filterDns(req, cfg) {
+		t.Error("request with multiple questions should not be filtered")
+	}
+}
+
+func TestFilterDns_NonARecord_NotFiltered(t *testing.T) {
+	cfg := newDiscardLogger()
+	req := newDNSQuery("example.com", layers.DNSTypeAAAA)
+	if filterDns(req, cfg) {
+		t.Error("non-A record query should not be filtered")
+	}
+}
+
+func TestFilterDns_EmptyBlocklistAndSafelist_PassThrough(t *testing.T) {
+	cfg := newDiscardLogger()
+	req := newDNSQuery("example.com", layers.DNSTypeA)
+	if filterDns(req, cfg) {
+		t.Error("query with no blocklist/safelist rules should pass through")
+	}
+}
+
+func TestFilterDns_Blocklist_DomainBlocked(t *testing.T) {
+	cfg := newDiscardLogger()
+	cfg.BlockList = []string{"evil.com"}
+	req := newDNSQuery("evil.com", layers.DNSTypeA)
+	if !filterDns(req, cfg) {
+		t.Error("domain on blocklist should be filtered")
+	}
+}
+
+func TestFilterDns_Blocklist_DomainNotBlocked(t *testing.T) {
+	cfg := newDiscardLogger()
+	cfg.BlockList = []string{"evil.com"}
+	req := newDNSQuery("good.com", layers.DNSTypeA)
+	if filterDns(req, cfg) {
+		t.Error("domain not on blocklist should pass through")
+	}
+}
+
+func TestFilterDns_Blocklist_WildcardBlocked(t *testing.T) {
+	cfg := newDiscardLogger()
+	cfg.BlockList = []string{"*.evil.com"}
+	req := newDNSQuery("sub.evil.com", layers.DNSTypeA)
+	if !filterDns(req, cfg) {
+		t.Error("wildcard blocklist domain should be filtered")
+	}
+}
+
+func TestFilterDns_Safelist_DomainAllowed(t *testing.T) {
+	cfg := newDiscardLogger()
+	cfg.SafeList = []string{"good.com"}
+	req := newDNSQuery("good.com", layers.DNSTypeA)
+	// Domain is on safelist → should NOT be filtered
+	if filterDns(req, cfg) {
+		t.Error("domain on safelist should pass through")
+	}
+}
+
+func TestFilterDns_Safelist_DomainBlocked(t *testing.T) {
+	cfg := newDiscardLogger()
+	cfg.SafeList = []string{"good.com"}
+	req := newDNSQuery("unlisted.com", layers.DNSTypeA)
+	// Safelist is active but domain is not on it → should be filtered
+	if !filterDns(req, cfg) {
+		t.Error("domain not on safelist should be filtered when safelist is active")
+	}
+}
+
+func TestFilterDns_Safelist_WildcardAllowed(t *testing.T) {
+	cfg := newDiscardLogger()
+	cfg.SafeList = []string{"*.safe.com"}
+	req := newDNSQuery("api.safe.com", layers.DNSTypeA)
+	if filterDns(req, cfg) {
+		t.Error("wildcard safelist domain should pass through")
+	}
+}
+
+func TestFilterDns_Safelist_WildcardBlocked(t *testing.T) {
+	cfg := newDiscardLogger()
+	cfg.SafeList = []string{"*.safe.com"}
+	req := newDNSQuery("api.other.com", layers.DNSTypeA)
+	if !filterDns(req, cfg) {
+		t.Error("domain not matching safelist wildcard should be filtered")
+	}
+}
+
+func TestFilterDns_SentinelDomain_Excluded(t *testing.T) {
+	cfg := newDiscardLogger()
+	cfg.ForwardToSentinel = true
+	cfg.LogAnalyticsWorkspaceId = "myworkspace"
+	// SafeList intentionally empty — domain still should not be filtered
+	cfg.SafeList = []string{"other.com"}
+	req := newDNSQuery("myworkspace.ods.opinsights.azure.com", layers.DNSTypeA)
+	if filterDns(req, cfg) {
+		t.Error("sentinel workspace domain should never be filtered")
+	}
+}
+
+func TestFilterDns_SentinelDisabled_WorkspaceDomainFiltered(t *testing.T) {
+	cfg := newDiscardLogger()
+	cfg.ForwardToSentinel = false
+	cfg.LogAnalyticsWorkspaceId = "myworkspace"
+	cfg.SafeList = []string{"other.com"}
+	req := newDNSQuery("myworkspace.ods.opinsights.azure.com", layers.DNSTypeA)
+	// ForwardToSentinel is false, domain is not on safelist → should be filtered
+	if !filterDns(req, cfg) {
+		t.Error("workspace domain should be filtered when ForwardToSentinel is false and not on safelist")
+	}
+}
+
+func TestFilterDns_Blocklist_SafelistTakesPrecedence(t *testing.T) {
+	// When SafeList is active, BlockList is ignored entirely.
+	cfg := newDiscardLogger()
+	cfg.SafeList = []string{"good.com"}
+	cfg.BlockList = []string{"good.com"} // blocklist is irrelevant when safelist is set
+	req := newDNSQuery("good.com", layers.DNSTypeA)
+	if filterDns(req, cfg) {
+		t.Error("safelist should take precedence over blocklist")
+	}
+}
+
+// helper to build a minimal DNS query with ID
+func makeDNSQueryWithID(id uint16, domain string, qtype layers.DNSType) *layers.DNS {
+	return &layers.DNS{
+		ID: id,
+		QR: false,
+		Questions: []layers.DNSQuestion{{Name: []byte(domain), Type: qtype}},
+	}
+}
+
+// Test the branch in proxyRequest that returns a filtered DNS response to the client.
+func TestProxyRequest_BlockedResponse(t *testing.T) {
+	// prepare a UDP listener that will act as the client receiving the response
+	recvConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("failed to create recv socket: %v", err)
+	}
+	defer recvConn.Close()
+
+	// sender socket used by proxyRequest to write responses
+	sendConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("failed to create send socket: %v", err)
+	}
+	defer sendConn.Close()
+
+	cfg := &Config{
+		Logger:    zerolog.New(io.Discard),
+		BlockList: []string{"evil.com"},
+	}
+
+	// Build a request that should be filtered
+	req := makeDNSQueryWithID(0x1234, "evil.com", layers.DNSTypeA)
+
+	// call the function under test
+	proxyRequest(sendConn, recvConn.LocalAddr(), req, cfg)
+
+	// read the response from the recv socket
+	_ = recvConn.SetReadDeadline(time.Now().Add(1 * time.Second))
+	buf := make([]byte, 65535)
+	n, _, err := recvConn.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+
+	packet := gopacket.NewPacket(buf[:n], layers.LayerTypeDNS, gopacket.Default)
+	dnsLayer := packet.Layer(layers.LayerTypeDNS)
+	if dnsLayer == nil {
+		t.Fatalf("no DNS layer in response")
+	}
+	resp := dnsLayer.(*layers.DNS)
+
+	if !resp.QR {
+		t.Errorf("expected response QR=true, got false")
+	}
+	if resp.ID != req.ID {
+		t.Errorf("expected response ID %d, got %d", req.ID, resp.ID)
+	}
+	if resp.ANCount != 0 {
+		t.Errorf("expected ANCount 0 for blocked response, got %d", resp.ANCount)
+	}
+}

--- a/dns_proxy_test.go
+++ b/dns_proxy_test.go
@@ -31,51 +31,122 @@ func newDNSQuery(domain string, qtype layers.DNSType) *layers.DNS {
 // ─── checkWildcard ───────────────────────────────────────────────────────────
 
 func TestCheckWildcard_ExactMatch(t *testing.T) {
-	if !checkWildcard("example.com", "example.com") {
+	if !checkWildcard("example.com", "example.com", false) {
 		t.Error("expected exact match to return true")
 	}
 }
 
 func TestCheckWildcard_WildcardSingleLabel(t *testing.T) {
-	if !checkWildcard("*.example.com", "foo.example.com") {
+	if !checkWildcard("*.example.com", "foo.example.com", false) {
 		t.Error("expected wildcard match to return true")
 	}
 }
 
 func TestCheckWildcard_WildcardDoesNotMatchSubdomain(t *testing.T) {
 	// *.example.com should NOT match foo.bar.example.com (different number of parts)
-	if checkWildcard("*.example.com", "foo.bar.example.com") {
+	if checkWildcard("*.example.com", "foo.bar.example.com", false) {
 		t.Error("expected length mismatch to return false")
 	}
 }
 
 func TestCheckWildcard_WildcardWrongLabel(t *testing.T) {
 	// Wildcard matches any single label, but second part must match
-	if checkWildcard("*.example.com", "foo.other.com") {
+	if checkWildcard("*.example.com", "foo.other.com", false) {
 		t.Error("expected non-matching label to return false")
 	}
 }
 
 func TestCheckWildcard_LengthMismatch_Shorter(t *testing.T) {
-	if checkWildcard("*.example.com", "example.com") {
+	if checkWildcard("*.example.com", "example.com", false) {
 		t.Error("expected shorter domain to return false")
 	}
 }
 
 func TestCheckWildcard_LengthMismatch_Longer(t *testing.T) {
-	if checkWildcard("example.com", "sub.example.com") {
+	if checkWildcard("example.com", "sub.example.com", false) {
 		t.Error("expected longer domain to return false")
 	}
 }
 
 func TestCheckWildcard_MultipleWildcards(t *testing.T) {
-	if !checkWildcard("*.*", "foo.bar") {
+	if !checkWildcard("*.*", "foo.bar", false) {
 		t.Error("expected double wildcard to match foo.bar")
 	}
 }
 
 func TestCheckWildcard_NoMatch(t *testing.T) {
-	if checkWildcard("example.com", "other.com") {
+	if checkWildcard("example.com", "other.com", false) {
+		t.Error("expected non-matching domain to return false")
+	}
+}
+
+// ─── checkWildcard greedy ─────────────────────────────────────────────────────
+
+func TestCheckWildcardGreedy_SingleLabelMatch(t *testing.T) {
+	if !checkWildcard("*.example.com", "bam.example.com", true) {
+		t.Error("expected single-label match to return true")
+	}
+}
+
+func TestCheckWildcardGreedy_MultiLabelMatch(t *testing.T) {
+	if !checkWildcard("*.example.com", "foo.bar.bam.example.com", true) {
+		t.Error("expected multi-label match to return true")
+	}
+}
+
+func TestCheckWildcardGreedy_ZeroLabelMatch(t *testing.T) {
+	// * can match zero labels
+	if !checkWildcard("*.example.com", "example.com", true) {
+		t.Error("expected zero-label match to return true")
+	}
+}
+
+func TestCheckWildcardGreedy_WildcardEndMatch(t *testing.T) {
+	// * can match at the end
+	if !checkWildcard("example.*", "example.foo.ca", true) {
+		t.Error("expected wildcard end match to return true")
+	}
+}
+
+func TestCheckWildcardGreedy_WrongSuffix(t *testing.T) {
+	if checkWildcard("*.example.com", "example.com.ca", true) {
+		t.Error("expected wrong suffix to return false")
+	}
+}
+
+func TestCheckWildcardGreedy_ExactMatch(t *testing.T) {
+	if !checkWildcard("example.com", "example.com", true) {
+		t.Error("expected exact match to return true")
+	}
+}
+
+func TestCheckWildcardGreedy_MiddleWildcard_SingleLabel(t *testing.T) {
+	if !checkWildcard("foo.*.example.com", "foo.bar.example.com", true) {
+		t.Error("expected middle wildcard single-label match to return true")
+	}
+}
+
+func TestCheckWildcardGreedy_MiddleWildcard_MultiLabel(t *testing.T) {
+	if !checkWildcard("foo.*.example.com", "foo.bar.bam.example.com", true) {
+		t.Error("expected middle wildcard multi-label match to return true")
+	}
+}
+
+func TestCheckWildcardGreedy_MiddleWildcard_ZeroLabel(t *testing.T) {
+	// * can match zero labels in middle position too
+	if !checkWildcard("foo.*.example.com", "foo.example.com", true) {
+		t.Error("expected middle wildcard zero-label match to return true")
+	}
+}
+
+func TestCheckWildcardGreedy_MiddleWildcard_WrongPrefix(t *testing.T) {
+	if checkWildcard("foo.*.example.com", "bar.baz.example.com", true) {
+		t.Error("expected wrong prefix to return false")
+	}
+}
+
+func TestCheckWildcardGreedy_WrongDomain(t *testing.T) {
+	if checkWildcard("*.example.com", "foo.other.com", true) {
 		t.Error("expected non-matching domain to return false")
 	}
 }
@@ -225,8 +296,8 @@ func TestFilterDns_Blocklist_SafelistTakesPrecedence(t *testing.T) {
 // helper to build a minimal DNS query with ID
 func makeDNSQueryWithID(id uint16, domain string, qtype layers.DNSType) *layers.DNS {
 	return &layers.DNS{
-		ID: id,
-		QR: false,
+		ID:        id,
+		QR:        false,
 		Questions: []layers.DNSQuestion{{Name: []byte(domain), Type: qtype}},
 	}
 }

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ func main() {
 	config := initConfig()
 
 	// Print config
-	config.Logger.Debug().
+	config.Logger.Info().
 		Str("host", config.Host).
 		Int64("port", config.Port).
 		Strs("blocklist", config.BlockList).
@@ -14,6 +14,7 @@ func main() {
 		Bool("forward_to_sentinel", config.ForwardToSentinel).
 		Bool("overwrite_config", config.OverwriteConfig).
 		Str("query_log_file_path", config.QueryLogFilePath).
+		Bool("wildcardgreedy", config.WildcardGreedy).
 		Msg("Configuration")
 
 	// Install the proxy server as the default DNS resolver

--- a/query_logger_test.go
+++ b/query_logger_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func newQueryLoggerConfig(t *testing.T) *Config {
+	t.Helper()
+	tmp := t.TempDir()
+	return &Config{
+		QueryLogFilePath: tmp + "/dns_query.log",
+		Logger:           zerolog.New(io.Discard),
+	}
+}
+
+func TestQueryLogger_Write_WithDomain(t *testing.T) {
+	cfg := newQueryLoggerConfig(t)
+	ql := QueryLogger{config: cfg}
+
+	event := []byte(`{"level":"info","domain":"example.com","action":"query"}` + "\n")
+	n, err := ql.Write(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(event) {
+		t.Errorf("Write returned %d bytes, expected %d", n, len(event))
+	}
+
+	contents, err := os.ReadFile(cfg.QueryLogFilePath)
+	if err != nil {
+		t.Fatalf("could not read log file: %v", err)
+	}
+	if !strings.Contains(string(contents), "example.com") {
+		t.Errorf("log file does not contain expected domain; got: %s", string(contents))
+	}
+}
+
+func TestQueryLogger_Write_WithoutDomain(t *testing.T) {
+	cfg := newQueryLoggerConfig(t)
+	ql := QueryLogger{config: cfg}
+
+	event := []byte(`{"level":"info","message":"no domain field here"}` + "\n")
+	n, err := ql.Write(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(event) {
+		t.Errorf("Write returned %d bytes, expected %d", n, len(event))
+	}
+
+	// File should not have been created because there is no "domain" field.
+	if _, statErr := os.Stat(cfg.QueryLogFilePath); !os.IsNotExist(statErr) {
+		t.Error("log file should not be written when event has no domain field")
+	}
+}
+
+func TestQueryLogger_Write_InvalidJSON(t *testing.T) {
+	cfg := newQueryLoggerConfig(t)
+	ql := QueryLogger{config: cfg}
+
+	_, err := ql.Write([]byte(`not valid json`))
+	if err == nil {
+		t.Error("expected error for invalid JSON input")
+	}
+}
+
+func TestQueryLogger_Write_MultipleEvents(t *testing.T) {
+	cfg := newQueryLoggerConfig(t)
+	ql := QueryLogger{config: cfg}
+
+	event1 := []byte(`{"level":"info","domain":"first.com","action":"query"}` + "\n")
+	event2 := []byte(`{"level":"info","domain":"second.com","action":"query"}` + "\n")
+
+	if _, err := ql.Write(event1); err != nil {
+		t.Fatalf("error writing event1: %v", err)
+	}
+	if _, err := ql.Write(event2); err != nil {
+		t.Fatalf("error writing event2: %v", err)
+	}
+
+	contents, err := os.ReadFile(cfg.QueryLogFilePath)
+	if err != nil {
+		t.Fatalf("could not read log file: %v", err)
+	}
+	if !strings.Contains(string(contents), "first.com") || !strings.Contains(string(contents), "second.com") {
+		t.Errorf("log file missing expected domains; got: %s", string(contents))
+	}
+}
+
+func TestQueryLogger_Write_MixedEvents(t *testing.T) {
+	cfg := newQueryLoggerConfig(t)
+	ql := QueryLogger{config: cfg}
+
+	withDomain := []byte(`{"level":"info","domain":"recorded.com","action":"query"}` + "\n")
+	withoutDomain := []byte(`{"level":"info","message":"startup"}` + "\n")
+
+	if _, err := ql.Write(withDomain); err != nil {
+		t.Fatalf("error writing domain event: %v", err)
+	}
+	if _, err := ql.Write(withoutDomain); err != nil {
+		t.Fatalf("error writing non-domain event: %v", err)
+	}
+
+	contents, err := os.ReadFile(cfg.QueryLogFilePath)
+	if err != nil {
+		t.Fatalf("could not read log file: %v", err)
+	}
+	if strings.Contains(string(contents), "startup") {
+		t.Error("log file should not contain non-domain events")
+	}
+	if !strings.Contains(string(contents), "recorded.com") {
+		t.Error("log file should contain domain event")
+	}
+}

--- a/sentinel_forwarder_test.go
+++ b/sentinel_forwarder_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// ─── buildSignature ───────────────────────────────────────────────────────────
+
+func TestBuildSignature_ReturnsSharedKeyFormat(t *testing.T) {
+	// Use a valid base64-encoded key so HMAC decoding succeeds.
+	sharedKey := base64.StdEncoding.EncodeToString([]byte("supersecret"))
+	sig := buildSignature("workspace-id", sharedKey, "Thu, 03 Apr 2026 12:00:00 GMT", "42", "POST", "application/json", "/api/logs")
+
+	if !strings.HasPrefix(sig, "SharedKey workspace-id:") {
+		t.Errorf("expected signature to start with 'SharedKey workspace-id:', got %q", sig)
+	}
+}
+
+func TestBuildSignature_DeterministicOutput(t *testing.T) {
+	sharedKey := base64.StdEncoding.EncodeToString([]byte("key"))
+	args := []string{"ws", sharedKey, "Mon, 01 Jan 2024 00:00:00 GMT", "10", "POST", "application/json", "/api/logs"}
+
+	sig1 := buildSignature(args[0], args[1], args[2], args[3], args[4], args[5], args[6])
+	sig2 := buildSignature(args[0], args[1], args[2], args[3], args[4], args[5], args[6])
+
+	if sig1 != sig2 {
+		t.Error("buildSignature should return the same value for identical inputs")
+	}
+}
+
+func TestBuildSignature_DifferentKeysDifferentSignatures(t *testing.T) {
+	key1 := base64.StdEncoding.EncodeToString([]byte("key1"))
+	key2 := base64.StdEncoding.EncodeToString([]byte("key2"))
+	date := "Mon, 01 Jan 2024 00:00:00 GMT"
+
+	sig1 := buildSignature("ws", key1, date, "10", "POST", "application/json", "/api/logs")
+	sig2 := buildSignature("ws", key2, date, "10", "POST", "application/json", "/api/logs")
+
+	if sig1 == sig2 {
+		t.Error("different keys should produce different signatures")
+	}
+}
+
+// ─── SentinelForwarder.Write ──────────────────────────────────────────────────
+
+// mockRoundTripper lets tests control the HTTP response returned by http.DefaultTransport.
+type mockRoundTripper struct {
+	statusCode int
+	body       string
+	err        error
+}
+
+func (m *mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &http.Response{
+		StatusCode: m.statusCode,
+		Body:       io.NopCloser(bytes.NewBufferString(m.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func setMockTransport(t *testing.T, status int) {
+	t.Helper()
+	orig := http.DefaultTransport
+	http.DefaultTransport = &mockRoundTripper{statusCode: status}
+	t.Cleanup(func() { http.DefaultTransport = orig })
+}
+
+func sentinelConfig() *Config {
+	return &Config{
+		ForwardToSentinel:       true,
+		LogAnalyticsWorkspaceId: "test-workspace",
+		LogAnalyticsSharedKey:   base64.StdEncoding.EncodeToString([]byte("shared-secret")),
+		LogAnalyticsTable:       "TestTable",
+	}
+}
+
+func TestSentinelForwarder_Write_ForwardingDisabled(t *testing.T) {
+	cfg := sentinelConfig()
+	cfg.ForwardToSentinel = false
+	sf := SentinelForwarder{config: cfg}
+
+	p := []byte(`{"level":"info","domain":"example.com"}` + "\n")
+	n, err := sf.Write(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(p) {
+		t.Errorf("expected %d bytes, got %d", len(p), n)
+	}
+}
+
+func TestSentinelForwarder_Write_NoDomainField(t *testing.T) {
+	cfg := sentinelConfig()
+	sf := SentinelForwarder{config: cfg}
+
+	p := []byte(`{"level":"info","message":"startup"}` + "\n")
+	n, err := sf.Write(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(p) {
+		t.Errorf("expected %d bytes, got %d", len(p), n)
+	}
+}
+
+func TestSentinelForwarder_Write_SuccessfulPost(t *testing.T) {
+	setMockTransport(t, http.StatusOK)
+	cfg := sentinelConfig()
+	sf := SentinelForwarder{config: cfg}
+
+	p := []byte(`{"level":"info","domain":"example.com","action":"query"}` + "\n")
+	n, err := sf.Write(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(p) {
+		t.Errorf("expected %d bytes, got %d", len(p), n)
+	}
+}
+
+func TestSentinelForwarder_Write_Non2xxResponse(t *testing.T) {
+	setMockTransport(t, http.StatusInternalServerError)
+	cfg := sentinelConfig()
+	sf := SentinelForwarder{config: cfg}
+
+	p := []byte(`{"level":"info","domain":"example.com","action":"query"}` + "\n")
+	n, err := sf.Write(p)
+	// On non-2xx, the function returns 0 with a nil error (matching production code).
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 bytes written on non-2xx response, got %d", n)
+	}
+}
+
+func TestSentinelForwarder_Write_202Accepted(t *testing.T) {
+	setMockTransport(t, http.StatusAccepted)
+	cfg := sentinelConfig()
+	sf := SentinelForwarder{config: cfg}
+
+	p := []byte(`{"level":"info","domain":"example.com","action":"blocked"}` + "\n")
+	n, err := sf.Write(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(p) {
+		t.Errorf("expected %d bytes, got %d", len(p), n)
+	}
+}
+
+func TestSentinelForwarder_Write_RequestContainsDomainPayload(t *testing.T) {
+	var capturedReq *http.Request
+	orig := http.DefaultTransport
+	http.DefaultTransport = &captureTransport{
+		captured:   &capturedReq,
+		statusCode: http.StatusOK,
+	}
+	t.Cleanup(func() { http.DefaultTransport = orig })
+
+	cfg := sentinelConfig()
+	sf := SentinelForwarder{config: cfg}
+
+	p := []byte(`{"level":"info","domain":"example.com","action":"query"}` + "\n")
+	sf.Write(p) //nolint:errcheck
+
+	if capturedReq == nil {
+		t.Fatal("expected an HTTP request to be made, but none was captured")
+	}
+	if capturedReq.Header.Get("Log-Type") != "TestTable" {
+		t.Errorf("Log-Type header: expected TestTable, got %q", capturedReq.Header.Get("Log-Type"))
+	}
+	if capturedReq.Method != http.MethodPost {
+		t.Errorf("expected POST method, got %q", capturedReq.Method)
+	}
+}
+
+// captureTransport records the request and returns a canned response.
+type captureTransport struct {
+	captured   **http.Request
+	statusCode int
+}
+
+func (c *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	*c.captured = req
+	return &http.Response{
+		StatusCode: c.statusCode,
+		Body:       io.NopCloser(bytes.NewBufferString("")),
+		Header:     make(http.Header),
+	}, nil
+}


### PR DESCRIPTION
# Summary
Update the action to include a setting (default: false) that causes the wildcard `*` to become greedy.  Currently the `*` only replaces a single domain label:

```bash
# "*.example.com" matches
www.example.com
foo.example.com

# "*.example.com" does not match
example.com
www.subdomain.example.com
```

With this change, the wildcard matches 0 or more labels with the following regular expression of `([^.]+)*`:

```bash
# "*.example.com" Will now match
example.com
foo.example.com
www.subdomain.example.com
```

## Other changes
- Adds unit tests and a CI workflow to run them.
- Fixes the devcontainer.
- Fixes the action so that it runs on both `amd64` and `arm64` runners.
- Fixes the readme documentation's configuration variable names.
- Fixes the parsing of slices for the blocklist and safelist.